### PR TITLE
640x480 mode fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build/*
+/doxygen
+/html

--- a/examples/01palettetest/01palettetest.ino
+++ b/examples/01palettetest/01palettetest.ino
@@ -10,6 +10,25 @@ DVHSTX8 display(DVHSTX_PINOUT_DEFAULT, DVHSTX_RESOLUTION_640x360);
 // The order is: {CKP, D0P, D1P, D2P} DVHSTX8 display({12, 14, 16, 18},
 // DVHSTX_RESOLUTION_640x360);
 
+struct moving_point {
+    int x, y, dx, dy;
+    void step() {
+        x += dx;
+        if (x < 0) { x = 0; dx = random(3) + 1; }
+        if (x >= display.width()) { x = display.width() - 1; dx = -random(3) - 1; }
+
+        y += dy;
+        if (y < 0) { y = 0; dy = random(3) + 1; }
+        if (y >= display.height()) { y = display.height() - 1; dy = -random(3) - 1; }
+    }
+};
+
+moving_point p1, p2;
+
+int random_with_sign(int n) {
+    return random(2) ? random(n-1)+1 : -random(n-1)-1;
+}
+
 void setup() {
   Serial.begin(115200);
   // while(!Serial);
@@ -19,12 +38,20 @@ void setup() {
       digitalWrite(LED_BUILTIN, (millis() / 500) & 1);
   }
   Serial.println("display initialized");
+  p1 = moving_point{random(display.width()), random(display.height()), random_with_sign(3), random_with_sign(3)};
+  p2 = moving_point{random(display.width()), random(display.height()), random_with_sign(3), random_with_sign(3)};
 }
 
 void loop() {
-  // Draw random lines
-  display.drawLine(random(display.width()), random(display.height()),
-                   random(display.width()), random(display.height()),
-                   random(65536));
-  sleep_ms(1);
+  static int j;
+  display.drawLine(p1.x, p1.y, p2.x, p2.y, 1 + (j + 254) % 255);
+Serial.printf("%d %d %d %d\r\n", p1.x, p1.y, p1.dx, p1.dy);
+  p1.step();
+  p2.step();
+
+  for(int i=1; i<256; i++) {
+    display.setColor(i, ((i + j) % 255) * 0x010101);
+  }
+  j += 1;
+  delay(3);
 }

--- a/src/Adafruit_dvhstx.cpp
+++ b/src/Adafruit_dvhstx.cpp
@@ -13,10 +13,14 @@ int16_t dvhstx_width(DVHSTXResolution r) {
     return 400;
   case DVHSTX_RESOLUTION_320x240:
     return 320;
+  case DVHSTX_RESOLUTION_640x480:
+    return 640;
   case DVHSTX_RESOLUTION_360x240:
     return 360;
   case DVHSTX_RESOLUTION_360x200:
     return 360;
+  case DVHSTX_RESOLUTION_720x400:
+    return 720;
   case DVHSTX_RESOLUTION_360x288:
     return 360;
   case DVHSTX_RESOLUTION_400x300:
@@ -42,10 +46,14 @@ int16_t dvhstx_height(DVHSTXResolution r) {
     return 225;
   case DVHSTX_RESOLUTION_320x240:
     return 240;
+  case DVHSTX_RESOLUTION_640x480:
+    return 480;
   case DVHSTX_RESOLUTION_360x240:
     return 240;
   case DVHSTX_RESOLUTION_360x200:
     return 200;
+  case DVHSTX_RESOLUTION_720x400:
+    return 400;
   case DVHSTX_RESOLUTION_360x288:
     return 288;
   case DVHSTX_RESOLUTION_400x300:

--- a/src/Adafruit_dvhstx.h
+++ b/src/Adafruit_dvhstx.h
@@ -27,10 +27,14 @@ struct enum {
 
         DVHSTX_RESOLUTION_320x240, ///< well supported, aspect ratio 4:3, actual
                                    ///< resolution 640x480@60Hz
+        DVHSTX_RESOLUTION_640x480, ///< well supported, aspect ratio 4:3, actual
+                                   ///< resolution 640x480@60Hz
         DVHSTX_RESOLUTION_360x240, ///< well supported, aspect ratio 3:2, actual
                                    ///< resolution 720x480@60Hz
         DVHSTX_RESOLUTION_360x200, ///< well supported, aspect ratio 9:5, actual
-                                   ///< resolution 720x400@70Hz
+                                   ///< resolution 720x400@70Hz (very close to 16:9)
+        DVHSTX_RESOLUTION_720x400, ///< well supported, aspect ratio 9:5, actual
+                                   ///< resolution 720x400@70Hz (very close to 16:9)
         DVHSTX_RESOLUTION_360x288, ///< well supported, aspect ratio 5:4, actual
                                    ///< resolution 720x576@60Hz
         DVHSTX_RESOLUTION_400x300, ///< well supported, aspect ratio 4:3, actual

--- a/src/Adafruit_dvhstx.h
+++ b/src/Adafruit_dvhstx.h
@@ -32,9 +32,11 @@ struct enum {
         DVHSTX_RESOLUTION_360x240, ///< well supported, aspect ratio 3:2, actual
                                    ///< resolution 720x480@60Hz
         DVHSTX_RESOLUTION_360x200, ///< well supported, aspect ratio 9:5, actual
-                                   ///< resolution 720x400@70Hz (very close to 16:9)
+                                   ///< resolution 720x400@70Hz (very close to
+                                   ///< 16:9)
         DVHSTX_RESOLUTION_720x400, ///< well supported, aspect ratio 9:5, actual
-                                   ///< resolution 720x400@70Hz (very close to 16:9)
+                                   ///< resolution 720x400@70Hz (very close to
+                                   ///< 16:9)
         DVHSTX_RESOLUTION_360x288, ///< well supported, aspect ratio 5:4, actual
                                    ///< resolution 720x576@60Hz
         DVHSTX_RESOLUTION_400x300, ///< well supported, aspect ratio 4:3, actual

--- a/src/drivers/dvhstx/dvhstx.cpp
+++ b/src/drivers/dvhstx/dvhstx.cpp
@@ -209,11 +209,15 @@ void __scratch_x("display") DVHSTX::gfx_dma_handler() {
                         *dst_ptr++ = val;
                         *dst_ptr++ = val;
                     }
-                }
-                else {
+                } else if (h_repeat_shift == 1) {
                     for (int i = 0; i < timing_mode->h_active_pixels; i += 2) {
                         uint32_t val = display_palette[*src_ptr++];
                         *dst_ptr++ = val;
+                        *dst_ptr++ = val;
+                    }
+                } else {
+                    for (int i = 0; i < timing_mode->h_active_pixels; i += 1) {
+                        uint32_t val = display_palette[*src_ptr++];
                         *dst_ptr++ = val;
                     }
                 }


### PR DESCRIPTION
This adds and fixes 640x480 and 720x400 modes.

When in palette mode, these modes were incorrect pixel doubled horizontally.

The palette demo was also changed to something that actually took advantage of palette changing.
![image](https://github.com/user-attachments/assets/b6d3c7d2-345f-4ee8-8d2b-7fb675193c7d)
