### PR TITLE
Adding common pin configs

### DIFF
--- a/src/common_dvi_hstx_pin_configs.h
+++ b/src/common_dvi_hstx_pin_configs.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "drivers/dvhstx/dvhstx.hpp"
+
+using pimoroni::DVHSTXPinout;
+
+static const DVHSTXPinout adafruit_hstxdvibell_cfg = {14, 12, 18, 16};
+static const DVHSTXPinout adafruit_metro_rp2350_cfg = {14, 18, 16, 12};
+static const DVHSTXPinout adafruit_feather_rp2350_cfg = {14, 18, 16, 12};
+static const DVHSTXPinout adafruit_fruit_jam_cfg = {13, 15, 17, 19};


### PR DESCRIPTION
I tested all four successfully on respective hardware with simpletest modified to

```
#include <common_dvi_hstx_pin_configs.h>

DVHSTX16 display(adafruit_feather_rp2350_cfg, DVHSTX_RESOLUTION_320x240);
DVHSTX16 display(adafruit_hstxdvibell_cfg, DVHSTX_RESOLUTION_320x240);
DVHSTX16 display(adafruit_metro_rp2350_cfg, DVHSTX_RESOLUTION_320x240);
DVHSTX16 display(adafruit_fruit_jam_cfg, DVHSTX_RESOLUTION_320x240);
```