### PR TITLE
Bail in case of out of memory

### DIFF
--- a/src/drivers/dvhstx/dvhstx.cpp
+++ b/src/drivers/dvhstx/dvhstx.cpp
@@ -657,7 +657,7 @@ bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_, bool double_buffe
     frame_buffer_display = (uint8_t*)malloc(frame_width * frame_height * frame_bytes_per_pixel);
     frame_buffer_back = double_buffered ? (uint8_t*)malloc(frame_width * frame_height * frame_bytes_per_pixel) : frame_buffer_display;
     if(frame_buffer_display == nullptr || frame_buffer_back == nullptr) {
-        dvhstx_debug("Out of memory for frame buffers");
+        dvhstx_debug("Out of memory for frame buffers\n");
         if (frame_buffer_display) {
             free(frame_buffer_display);
             frame_buffer_display = nullptr;

--- a/src/drivers/dvhstx/dvhstx.cpp
+++ b/src/drivers/dvhstx/dvhstx.cpp
@@ -656,6 +656,14 @@ bool DVHSTX::init(uint16_t width, uint16_t height, Mode mode_, bool double_buffe
 #else
     frame_buffer_display = (uint8_t*)malloc(frame_width * frame_height * frame_bytes_per_pixel);
     frame_buffer_back = double_buffered ? (uint8_t*)malloc(frame_width * frame_height * frame_bytes_per_pixel) : frame_buffer_display;
+    if(frame_buffer_display == nullptr || frame_buffer_back == nullptr) {
+        dvhstx_debug("Out of memory for frame buffers");
+        if (frame_buffer_display) {
+            free(frame_buffer_display);
+            frame_buffer_display = nullptr;
+        }
+        return false;
+    }
 #endif
     memset(frame_buffer_display, 0, frame_width * frame_height * frame_bytes_per_pixel);
     memset(frame_buffer_back, 0, frame_width * frame_height * frame_bytes_per_pixel);


### PR DESCRIPTION
This code block blindly `malloc()`s its main framebuffer and optionally a second back buffer, but never checks if it actually got any memory back. This will cause the subseqeuent `memset()`s calls to crash, in case of memory allocation failure.

This code change handles it more gracefully and also deallocates the main framebuffer in case the main framebuffer could be allocated but the back buffer couldn't be allocated.

Crash with this was observed on a Adafruit Metro RP2350.